### PR TITLE
fixed false negatives in point_within_polygon

### DIFF
--- a/lib/Polygons.ml
+++ b/lib/Polygons.ml
@@ -291,6 +291,22 @@ let neighbours_on_different_sides ray pol p =
     let dir2 = direction r s b in
     dir1 <> dir2
 
+(* Ensure that no points in a list are neighbors of any point in the list *)              
+let neighbours_filter pol points =
+  let rec iter pts acc =
+    match pts with
+    | [] -> acc
+    | v :: tl ->
+       if List.mem v pol then
+         let (neighbour_1, neighbour_2) = get_vertex_neighbours pol v in
+         if List.mem neighbour_1 tl || List.mem neighbour_2 tl
+         then iter tl acc
+         else iter tl @@ v :: acc
+       else
+         iter tl @@ v :: acc
+         
+  in
+  iter points []
 
 (* Point within a polygon *)
 
@@ -312,6 +328,9 @@ let point_within_polygon pol p =
 
         (* Touching vertices *)
         List.filter (neighbours_on_different_sides ray pol) |>
+
+        neighbours_filter pol |>
+          
 
         (* Compute length *)
         List.length

--- a/lib/Polygons.ml
+++ b/lib/Polygons.ml
@@ -311,13 +311,13 @@ let neighbours_filter pol points =
 (* Point within a polygon *)
 
 let point_within_polygon pol p = 
-  let ray = (p, 0.) in
   let es = edges pol in
   if List.mem p pol ||
      List.exists (fun e -> point_on_segment e p) es then true
   else
     begin
-      let n = 
+      let n angle =
+        let ray = (p, angle) in
         edges pol |> 
         List.map (fun e -> ray_segment_intersection ray e) |>
         List.filter (fun r -> r <> None) |>
@@ -329,13 +329,13 @@ let point_within_polygon pol p =
         (* Touching vertices *)
         List.filter (neighbours_on_different_sides ray pol) |>
 
-        neighbours_filter pol |>
+          neighbours_filter pol |>
           
 
         (* Compute length *)
-        List.length
+          List.length
       in
-      n mod 2 = 1
+      n 0. mod 2 = 1 && n pi mod 2 = 1
     end
 
 (*

--- a/lib/Tests.ml
+++ b/lib/Tests.ml
@@ -98,7 +98,7 @@ let test_random_ch n =
   assert (List.for_all (point_within_polygon ch) ps)
 
 
-let%test _ = 
+let%test _ =
   for _ = 0 to 100 do
     test_random_ch 50
   done;


### PR DESCRIPTION
The current `point_within_polygon` function returns false negatives for some points in rectilinear polygons. To reproduce this bug, create a polygon with points identical to the first room in exercise 1.3 in the final, and check if the point (1,1) is within this polygon:

```
let p = [Point (0., 0.); Point (6., 0.); Point (6., 1.); Point (8., 1.); Point (8., 2.); Point (6., 2.); Point (6., 3.); Point (0., 3.)];;
point_within_polygon p @@ Point (1.,1.);;
```
The point (1,1) is within this polygon, but the `point_within_polygon` function returns false when evaluated with these arguments.

This problem results from the `point_within_polygon` not correctly considering the number of intersections between a point and an edge. In the example above, the ray extending from (1,1) at 0 rad intersects with the points (6,1) and (8,1) in the polygon. Since this is an even number of points, the `point_within_polygon` function returns false. However, these two points are neighbors, since they lie on the same edge. The ray extending from (1,1) at 0 rad, then, really only intersects with the the polygon once: at the edge defined by the points (6,1) and (8,1).

I resolve this bug by adding an additional filter to `point_within_polygon` that removes intersection points that are neighbors of other intersection points.